### PR TITLE
Support cluster job submission for Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,21 @@ This will:
     - Interact with GPT-OSS fully offline after first model pull
 
 ----------------------------------------------------------------------
-7. Troubleshooting
+7. Running on a Cluster
+----------------------------------------------------------------------
+
+This project includes helper scripts to launch the Streamlit interface on a
+Slurm cluster. After configuring your cluster in ``clusters.yml`` you can
+submit a job from your local machine:
+
+    python main_cluster.py --cluster <name> --submit-app --model llama3.1:8b
+
+The command prints the Slurm job ID and instructions for creating an SSH
+tunnel once the job is running. For an interactive session instead, replace
+``--submit-app`` with ``--interactive-app``.
+
+----------------------------------------------------------------------
+8. Troubleshooting
 ----------------------------------------------------------------------
 
 - If `ollama` is not found:
@@ -125,7 +139,7 @@ This will:
     - It may be due to network speed; model files are large (GBs).
 
 ----------------------------------------------------------------------
-8. Conclusion
+9. Conclusion
 ----------------------------------------------------------------------
 
 After completing these steps, you can run GPT-OSS locally with full control,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit>=1.35
 ollama>=0.3.0
+pyyaml


### PR DESCRIPTION
## Summary
- enable non-interactive Slurm job submission to launch Ollama and Streamlit via new `submit_app_job`
- expose `--submit-app` option in `main_cluster.py` for remote cluster runs
- document cluster usage and add `pyyaml` dependency

## Testing
- `python -m py_compile hpc.py main_cluster.py`
- `python main_cluster.py --help` *(fails: No module named 'yaml')*
